### PR TITLE
Update readme with binder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![Pytest and flake8](https://github.com/GMOD/jbrowse-jupyter/actions/workflows/push.yml/badge.svg)
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/GMOD/jbrowse-jupyter/blob/main/browser.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/GMOD/jbrowse-jupyter/main?labpath=browser.ipynb)
 
 # [JBrowse Jupyter](https://gmod.github.io/jbrowse-jupyter/)
 


### PR DESCRIPTION
Just resolved the issues with binder and have added a link to the repo. 
Binder is making use of our requirements.txt to set up the environment. https://mybinder.readthedocs.io/en/latest/using/config_files.html

