### PR TITLE
remove binder badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Pytest and flake8](https://github.com/GMOD/jbrowse-jupyter/actions/workflows/push.yml/badge.svg)
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/GMOD/jbrowse-jupyter/blob/main/browser.ipynb)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/GMOD/jbrowse-jupyter/main?labpath=browser.ipynb)
-
+<!-- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/GMOD/jbrowse-jupyter/main?labpath=browser.ipynb)
+ -->
 # [JBrowse Jupyter](https://gmod.github.io/jbrowse-jupyter/)
 
 JBrowse Jupyter is a python package that provides a python interface to JBrowse views.


### PR DESCRIPTION
* there is an issue with jupyterlab and the widgets extension that is causing 504 in the binder notebook