### PR TITLE
Incorrect display type for quantitative track

### DIFF
--- a/jbrowse_jupyter/tracks.py
+++ b/jbrowse_jupyter/tracks.py
@@ -43,7 +43,7 @@ def guess_display_type(track_type, view="LGV"):
         "AlignmentsTrack": "LinearAlignmentsDisplay",
         "VariantTrack": "LinearVariantDisplay",
         "ReferenceSequenceTrack": "LinearReferenceSequenceDisplay",
-        "QuantitativeTrack": "LinearBasicDisplay",
+        "QuantitativeTrack": "LinearWiggleDisplay",
         "FeatureTrack": "LinearBasicDisplay",
     }
     if view == "CGV":

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="jbrowse-jupyter",
-    version="1.2.8",
+    version="1.2.9",
     author="Teresa De Jesus Martinez",
     author_email="tere486martinez@gmail.com",
     maintainer="Teresa De Jesus Martinez; JBrowse Team",


### PR DESCRIPTION
* provides bug fix for guess display helper function which incorrectly mapped the quantitative track to a LinearBasicDisplay instead of the correctly LinearWiggleDisplay
* the incorrect mapping caused mob x state tree errors when setting the default session with a quantitative track