### PR TITLE
revert dash version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dash==2.3.0
-dash-jbrowse>=1.1.1
+dash-jbrowse==1.1.0
 jupyter_dash>=0.4.2
 Werkzeug==2.0.3
 pandas>=1.1.5

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="jbrowse-jupyter",
-    version="1.3.2",
+    version="1.3.3",
     author="Teresa De Jesus Martinez",
     author_email="tere486martinez@gmail.com",
     maintainer="Teresa De Jesus Martinez; JBrowse Team",


### PR DESCRIPTION
* There is a bug in dash-jbrowse after upgrading to 2.0.0 for the embedded components. 
* Will revert for now.