### PR TITLE
Feat uri scheme

### DIFF
--- a/jbrowse_jupyter/jbrowse_config.py
+++ b/jbrowse_jupyter/jbrowse_config.py
@@ -157,11 +157,11 @@ class JBrowseConfig:
         return self.jupyter
 
     def get_env(self):
-        print("notebook port: ", self.nb_port)
-        print("notebook host: ", self.nb_host)
         print("notebook scheme: ", self.nb_scheme)
+        print("notebook host: ", self.nb_host)
+        print("notebook port: ", self.nb_port)
         
-        return nb_scheme, self.nb_host, self.nb_port 
+        return self.nb_scheme, self.nb_host, self.nb_port 
 
     def set_env(self, notebook_scheme="http", notebook_host="localhost", notebook_port=8888):
         """

--- a/jbrowse_jupyter/jbrowse_config.py
+++ b/jbrowse_jupyter/jbrowse_config.py
@@ -161,7 +161,7 @@ class JBrowseConfig:
         print("notebook host: ", self.nb_host)
         print("notebook scheme: ", self.nb_scheme)
         
-        return self.nb_host, self.nb_port, nb_scheme
+        return nb_scheme, self.nb_host, self.nb_port 
 
     def set_env(self, notebook_scheme="http", notebook_host="localhost", notebook_port=8888):
         """

--- a/jbrowse_jupyter/jbrowse_config.py
+++ b/jbrowse_jupyter/jbrowse_config.py
@@ -132,6 +132,7 @@ class JBrowseConfig:
         # environment
         self.nb_port = 8888
         self.nb_host = "localhost"
+        self.nb_scheme = "http"
         self.colab = in_colab_notebook
         self.jupyter = not in_colab_notebook and in_jupyter_notebook
 
@@ -158,11 +159,13 @@ class JBrowseConfig:
     def get_env(self):
         print("notebook port: ", self.nb_port)
         print("notebook host: ", self.nb_host)
-        return self.nb_host, self.nb_port
+        print("notebook scheme: ", self.nb_scheme)
+        
+        return self.nb_host, self.nb_port, nb_scheme
 
-    def set_env(self, notebook_host="localhost", notebook_port=8888):
+    def set_env(self, notebook_scheme="http", notebook_host="localhost", notebook_port=8888):
         """
-        Changes the port and the host for creating links to files
+        Changes the schemen, port and the host for creating links to files
         found within the file tree of jupyter.
 
         We want to be able to use paths to local files that can be
@@ -174,11 +177,18 @@ class JBrowseConfig:
         browser = create("LGV")
         browser.set_env("localhost", 8989)
 
+        or alternatively
+        browser.set_env(notebook_scheme="https", notebook_host="example.org", notebook_port=8989)
+
+        :param str notebook_scheme: scheme used in jupyter config for
+            for using paths to local files. (Defaults to http)
         :param str notebook_host: host used in jupyter config for
             for using paths to local files. (Defaults to "localhost")
         :param str notebook_port: port used in jupyter config for
             for using paths to local files. (Defaults to 8888)
+
         """
+        self.nb_scheme = notebook_scheme
         self.nb_port = notebook_port
         self.nb_host = notebook_host
 
@@ -285,6 +295,7 @@ class JBrowseConfig:
                                                   'localPath',
                                                   indx,
                                                   colab=self.colab,
+                                                  nb_scheme=self.nb_scheme,
                                                   nb_port=self.nb_port,
                                                   nb_host=self.nb_host)
             name = kwargs.get('name', get_name(assembly_data))
@@ -461,6 +472,7 @@ class JBrowseConfig:
                 else:
                     adapter = guess_adapter_type(data, 'localPath', index,
                                                  colab=self.colab,
+                                                 nb_scheme=self.nb_scheme,
                                                  nb_port=self.nb_port,
                                                  nb_host=self.nb_host)
             else:
@@ -527,6 +539,7 @@ class JBrowseConfig:
             adapter = guess_adapter_type(data, 'localPath',
                                          index,
                                          colab=self.colab,
+                                         nb_scheme=self.nb_scheme,
                                          nb_port=self.nb_port,
                                          nb_host=self.nb_host
                                          )
@@ -734,6 +747,7 @@ class JBrowseConfig:
                 "uri":  make_url_colab_jupyter(
                     ix,
                     colab=self.colab,
+                    nb_scheme=self.nb_scheme,
                     nb_host=self.nb_host,
                     nb_port=self.nb_port
                 ),
@@ -743,6 +757,7 @@ class JBrowseConfig:
                 "uri": make_url_colab_jupyter(
                     ixx,
                     colab=self.colab,
+                    nb_scheme=self.nb_scheme,
                     nb_host=self.nb_host,
                     nb_port=self.nb_port
                 ),
@@ -752,6 +767,7 @@ class JBrowseConfig:
                 "uri": make_url_colab_jupyter(
                     meta,
                     colab=self.colab,
+                    nb_scheme=self.nb_scheme,
                     nb_host=self.nb_host,
                     nb_port=self.nb_port
                 ),

--- a/jbrowse_jupyter/tracks.py
+++ b/jbrowse_jupyter/tracks.py
@@ -14,6 +14,7 @@ def make_location(location, protocol, **kwargs):
 
     """
     in_colab = kwargs.get('colab', False)
+    notebook_scheme = kwargs.get('nb_scheme', "http")
     notebook_host = kwargs.get('nb_host', 8888)
     notebook_port = kwargs.get('nb_port', "localhost")
     if protocol == "uri":
@@ -22,6 +23,7 @@ def make_location(location, protocol, **kwargs):
         return {
             "uri": make_url_colab_jupyter(location,
                                           colab=in_colab,
+                                          nb_scheme=notebook_scheme,
                                           nb_port=notebook_port,
                                           nb_host=notebook_host),
             "locationType": "UriLocation"
@@ -33,11 +35,13 @@ def make_location(location, protocol, **kwargs):
 def make_url_colab_jupyter(location, **kwargs):
     """Generates url from path based on env colab or jupyter"""
     in_colab = kwargs.get('colab', False)
+    notebook_scheme = kwargs.get('nb_scheme', "http")
     notebook_host = kwargs.get('nb_host', 8888)
     notebook_port = kwargs.get('nb_port', "localhost")
+
     if in_colab:
         return location
-    return f'http://{notebook_host}:{notebook_port}/files' + location
+    return f'{notebook_scheme}://{notebook_host}:{notebook_port}/files' + location
 
 
 def supported_track_type(track_type):
@@ -114,6 +118,7 @@ def guess_adapter_type(file_location,
     :return: the adapter track subconfiguration
     :rtype: obj
     """
+    notebook_scheme = kwargs.get('nb_scheme', "http")
     notebook_host = kwargs.get('nb_host', 8888)
     notebook_port = kwargs.get('nb_port', "localhost")
     in_colab = kwargs.get('colab', False)
@@ -145,12 +150,14 @@ def guess_adapter_type(file_location,
             "bamLocation": make_location(file_location,
                                          protocol,
                                          colab=in_colab,
+                                         nb_scheme=notebook_scheme,
                                          nb_host=notebook_host,
                                          nb_port=notebook_port),
             "index": {
                 "location": make_location(f"{file_location}.bai",
                                           protocol,
                                           colab=in_colab,
+                                          nb_scheme=notebook_scheme,
                                           nb_host=notebook_host,
                                           nb_port=notebook_port),
                 "indexType": "CSI"
@@ -165,11 +172,13 @@ def guess_adapter_type(file_location,
             "cramLocation": make_location(file_location,
                                           protocol,
                                           colab=in_colab,
+                                          nb_scheme=notebook_scheme,
                                           nb_host=notebook_host,
                                           nb_port=notebook_port),
             "craiLocation": make_location(f"{file_location}.crai",
                                           protocol,
                                           colab=in_colab,
+                                          nb_scheme=notebook_scheme,
                                           nb_host=notebook_host,
                                           nb_port=notebook_port),
         }
@@ -193,12 +202,14 @@ def guess_adapter_type(file_location,
             "gffGzLocation": make_location(file_location,
                                            protocol,
                                            colab=in_colab,
+                                           nb_scheme=notebook_scheme,
                                            nb_host=notebook_host,
                                            nb_port=notebook_port),
             "index": {
                 "location": make_location(f"{file_location}.tbi",
                                           protocol,
                                           colab=in_colab,
+                                          nb_scheme=notebook_scheme,
                                           nb_host=notebook_host,
                                           nb_port=notebook_port),
                 "indexType": "TBI",
@@ -212,6 +223,7 @@ def guess_adapter_type(file_location,
             "vcfLocation": make_location(file_location,
                                          protocol,
                                          colab=in_colab,
+                                         nb_scheme=notebook_scheme,
                                          nb_host=notebook_host,
                                          nb_port=notebook_port),
         }
@@ -229,12 +241,14 @@ def guess_adapter_type(file_location,
             "vcfGzLocation": make_location(file_location,
                                            protocol,
                                            colab=in_colab,
+                                           nb_scheme=notebook_scheme,
                                            nb_host=notebook_host,
                                            nb_port=notebook_port),
             "index": {
                 "location": make_location(f"{file_location}.tbi",
                                           protocol,
                                           colab=in_colab,
+                                          nb_scheme=notebook_scheme,
                                           nb_host=notebook_host,
                                           nb_port=notebook_port),
                 "indexType": "CSI"
@@ -250,6 +264,7 @@ def guess_adapter_type(file_location,
             "bigWigLocation": make_location(file_location,
                                             protocol,
                                             colab=in_colab,
+                                            nb_scheme=notebook_scheme,
                                             nb_host=notebook_host,
                                             nb_port=notebook_port),
         }
@@ -266,12 +281,14 @@ def guess_adapter_type(file_location,
             "bedGzLocation": make_location(file_location,
                                            protocol,
                                            colab=in_colab,
+                                           nb_scheme=notebook_scheme,
                                            nb_host=notebook_host,
                                            nb_port=notebook_port),
             "index": {
                 "location": make_location(f"{file_location}.tbi",
                                           protocol,
                                           colab=in_colab,
+                                          nb_scheme=notebook_scheme,
                                           nb_host=notebook_host,
                                           nb_port=notebook_port),
                 "indexType": "CSI"
@@ -287,6 +304,7 @@ def guess_adapter_type(file_location,
             "bigBedLocation": make_location(file_location,
                                             protocol,
                                             colab=in_colab,
+                                            nb_scheme=notebook_scheme,
                                             nb_host=notebook_host,
                                             nb_port=notebook_port),
         }
@@ -299,10 +317,12 @@ def guess_adapter_type(file_location,
             "fastaLocation": make_location(file_location,
                                            protocol,
                                            colab=in_colab,
+                                           nb_scheme=notebook_scheme,
                                            nb_host=notebook_host,
                                            nb_port=notebook_port),
             "faiLocation": make_location(fai, protocol,
                                          colab=in_colab,
+                                         nb_scheme=notebook_scheme,
                                          nb_host=notebook_host,
                                          nb_port=notebook_port),
         }
@@ -314,16 +334,19 @@ def guess_adapter_type(file_location,
             "fastaLocation": make_location(file_location,
                                            protocol,
                                            colab=in_colab,
+                                           nb_scheme=notebook_scheme,
                                            nb_host=notebook_host,
                                            nb_port=notebook_port),
             "faiLocation": make_location(f"{file_location}.fai",
                                          protocol,
                                          colab=in_colab,
+                                         nb_scheme=notebook_scheme,
                                          nb_host=notebook_host,
                                          nb_port=notebook_port),
             "gziLocation": make_location(f"{file_location}.gzi",
                                          protocol,
                                          colab=in_colab,
+                                         nb_scheme=notebook_scheme,
                                          nb_host=notebook_host,
                                          nb_port=notebook_port),
         }
@@ -335,6 +358,7 @@ def guess_adapter_type(file_location,
             "twoBitLocation": make_location(file_location,
                                             protocol,
                                             colab=in_colab,
+                                            nb_scheme=notebook_scheme,
                                             nb_host=notebook_host,
                                             nb_port=notebook_port),
         }
@@ -350,6 +374,7 @@ def guess_adapter_type(file_location,
             "rootUrlTemplate": make_location(file_location,
                                              protocol,
                                              colab=in_colab,
+                                             nb_scheme=notebook_scheme,
                                              nb_host=notebook_host,
                                              nb_port=notebook_port),
         }
@@ -361,6 +386,7 @@ def guess_adapter_type(file_location,
             "endpoint": make_location(file_location,
                                       protocol,
                                       colab=in_colab,
+                                      nb_scheme=notebook_scheme,
                                       nb_host=notebook_host,
                                       nb_port=notebook_port),
         }
@@ -371,6 +397,7 @@ def guess_adapter_type(file_location,
             "hicLocation": make_location(file_location,
                                          protocol,
                                          colab=in_colab,
+                                         nb_scheme=notebook_scheme,
                                          nb_host=notebook_host,
                                          nb_port=notebook_port),
         }
@@ -382,6 +409,7 @@ def guess_adapter_type(file_location,
             "pafLocation": make_location(file_location,
                                          protocol,
                                          colab=in_colab,
+                                         nb_scheme=notebook_scheme,
                                          nb_host=notebook_host,
                                          nb_port=notebook_port),
         }


### PR DESCRIPTION
added notebook_scheme kwarg to jbrowse_config.set_env to enable https support instead of hardcoded http scheme in make_url_colab_jupyter in tracks.py