### PR TITLE
Updates deprecated alias run_server and removes restrictions on dataframe add track workflow

### DIFF
--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -70,7 +70,7 @@ app.layout = html.Div(
 )
 
 if __name__ == "__main__":
-    app.run_server(port=8081, debug=True)
+    app.run(port=8081, debug=True)
 
 ```
 

--- a/examples/cgv_examples.py
+++ b/examples/cgv_examples.py
@@ -116,4 +116,4 @@ app.layout = html.Div(
 )
 
 if __name__ == "__main__":
-    app.run_server(port=3003, debug=True)
+    app.run(port=3003, debug=True)

--- a/examples/dash_callbacks.ipynb
+++ b/examples/dash_callbacks.ipynb
@@ -117,7 +117,7 @@
     }
    ],
    "source": [
-    "app.run_server(mode=\"external\", use_reloader=False, debug=True, port=3039)"
+    "app.run(mode=\"external\", use_reloader=False, debug=True, port=3039)"
    ]
   }
  ],

--- a/examples/non_notebook_usage.ipynb
+++ b/examples/non_notebook_usage.ipynb
@@ -55,4 +55,4 @@ component = create_component(config)
 app.layout = html.Div([component], id="test")
 
 if __name__ == "__main__":
-    app.run_server(port=3001, debug=True)
+    app.run(port=3001, debug=True)

--- a/examples/skbr3.ipynb
+++ b/examples/skbr3.ipynb
@@ -256,7 +256,7 @@
     }
    ],
    "source": [
-    "app.run_server(mode=\"inline\", height=1000, use_reloader=False, debug=True, port=3031)\n"
+    "app.run(mode=\"inline\", height=1000, use_reloader=False, debug=True, port=3031)\n"
    ]
   }
  ],

--- a/jbrowse_jupyter/tracks.py
+++ b/jbrowse_jupyter/tracks.py
@@ -491,7 +491,7 @@ def check_columns(df):
         "value": "score"
     }
     # assigns arbitrary name to name column if it doesn't exist for a feature track from df
-    if not 'name' in df:
+    if 'name' not in df:
         df['name'] = 'feature' + df.index.astype(str)
     df.rename(mapper=mapper, axis=1, inplace=True)
     return all(col in df for col in required)

--- a/jbrowse_jupyter/util.py
+++ b/jbrowse_jupyter/util.py
@@ -316,7 +316,7 @@ def launch(conf, **kwargs):
             )
     else:
         raise TypeError(f"The {dash_comp} component is not supported.")
-    app.run_server(
+    app.run(
         port=comp_port,
         host=comp_host,
         height=comp_height,

--- a/tests/test_tracks.py
+++ b/tests/test_tracks.py
@@ -133,7 +133,7 @@ def test_check_track_data():
 
 
 def test_check_columns():
-    column_error = "DataFrame must contain all required columns."
+    column_error = "DataFrame must contain all required columns (refName, start, end, name)."
     invalid_df = {
         "refName": ["1", "1"],
         "end": [780, 101112],


### PR DESCRIPTION
- Updates deprecated alias Dash run_server to Dash run
- removes restrictions on df add track workflow that prevented "out of the box" bigWig files from computing properly

Users can now convert their BigWig data to a dataframe and load it directly into the library without having to change their headers or datatypes.
